### PR TITLE
Remove references to old U8NWXD repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ You can use this action in a GitHub Actions workflow like this:
 ```yml
   - name: Retrieve token
     id: get-token
-    uses: U8NWXD/get-github-app-token@release-v0.0.1
+    uses: oppia/get-github-app-token@release-v0.0.1
     with:
       app_id: ${{ secrets.APP_ID }}
       private_key: ${{ secrets.APP_PRIVATE_KEY }}

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-// Copyright 2022 U8NWXD
+// Copyright 2022 The Oppia Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/package.json
+++ b/package.json
@@ -6,8 +6,11 @@
   "scripts": {
     "dist": "yarn ncc build -o dist index.js --license licenses.txt && cp action.yml dist/"
   },
-  "repository": "https://github.com/U8NWXD/get-github-app-token.git",
-  "author": "U8NWXD",
+  "repository": {
+      "type": "git",
+      "url": "git+https://github.com/oppia/get-github-app-token.git"
+  },
+  "author": "",
   "license": "Apache-2.0",
   "dependencies": {
     "@actions/core": "^1.6.0",

--- a/release.sh
+++ b/release.sh
@@ -1,4 +1,4 @@
-# Copyright 2022 U8NWXD
+# Copyright 2022 The Oppia Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@
 
 set -e
 
-RELEASE_REMOTE="git@github.com:U8NWXD/get-github-app-token"
+RELEASE_REMOTE="git@github.com:oppia/get-github-app-token"
 
 version="$1"
 

--- a/utils.js
+++ b/utils.js
@@ -1,4 +1,4 @@
-// Copyright 2022 U8NWXD
+// Copyright 2022 The Oppia Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
This PR does the following:

* Updates URLs to point to the oppia/get-github-app-token repository instead of the U8NWXD/get-github-app-token repository we forked from.
* Updates copyright statements to identify the Oppia authors as the copyright owners instead of just U8NWXD (who is among the Oppia authors)

There are no changes to the GitHub Action's code here, so we don't need to create a new release for this.